### PR TITLE
handle deprecated get_cache() function

### DIFF
--- a/debug_panel/cache.py
+++ b/debug_panel/cache.py
@@ -1,7 +1,14 @@
-from django.core.cache import get_cache
+import django
 from django.core.cache.backends.base import InvalidCacheBackendError
+from distutils.version import StrictVersion
+
 
 try:
-    cache = get_cache('debug-panel')
+    if StrictVersion(django.get_version()) >= StrictVersion('1.7'):
+        from django.core.cache import get_cache
+        cache = get_cache('debug-panel')
+    else:
+        from django.core.cache import caches
+        cache = caches['debug-panel']
 except InvalidCacheBackendError:
     from django.core.cache import cache


### PR DESCRIPTION
Using get_cache() in Django 1.7 or above generates annoying deprecation warning. This function will be removed in Django 1.9. This fix handles Django version and uses appropriate API.