### PR TITLE
Works with debug toolbar >= 1.4

### DIFF
--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -61,6 +61,11 @@ class DebugPanelMiddleware(debug_toolbar.middleware.DebugToolbarMiddleware):
         response = super(DebugPanelMiddleware, self).process_response(request, response)
 
         if toolbar:
+            # for django-debug-toolbar >= 1.4
+            for panel in reversed(toolbar.enabled_panels):
+                if hasattr(panel, 'generate_stats'):
+                    panel.generate_stats(request, response)
+
             cache_key = "%f" % time.time()
             cache.set(cache_key, toolbar.render_toolbar())
 


### PR DESCRIPTION
In debug toolbar 1.4, it was added Panel.generate_stats() method.
In process_response() method, should call generate_stats.

see:
- https://github.com/django-debug-toolbar/django-debug-toolbar/blob/1.4/debug_toolbar/middleware.py#L129
- https://github.com/django-debug-toolbar/django-debug-toolbar/blob/1.4/debug_toolbar/panels/__init__.py#L182