### PR TITLE
Update urls.py for Django 1.10 compatibility

### DIFF
--- a/debug_panel/urls.py
+++ b/debug_panel/urls.py
@@ -4,13 +4,27 @@ URLpatterns for the debug panel.
 These should not be loaded explicitly; It is used internally by the
 debug-panel application.
 """
-try:
-    from django.conf.urls import patterns, url
-except ImportError:  # django < 1.4
-    from django.conf.urls.defaults import patterns, url
+from distutils.version import StrictVersion
+import django
 
 _PREFIX = '__debug__'
 
-urlpatterns = patterns('debug_panel.views',
-    url(r'^%s/data/(?P<cache_key>\d+\.\d+)/$' % _PREFIX, 'debug_data', name='debug_data'),
-)
+if StrictVersion(django.get_version()) < StrictVersion('1.9'):
+    # Handle legacy urls.py, which use the patterns function to build urls
+    try:
+        from django.conf.urls import patterns, url
+    except ImportError:  # django < 1.4
+        from django.conf.urls.defaults import patterns, url
+
+    urlpatterns = patterns('debug_panel.views',
+        url(r'^%s/data/(?P<cache_key>\d+\.\d+)/$' % _PREFIX, 'debug_data', name='debug_data'),
+    )
+else:
+    # Django 1.9+ uses just a list of url instances, and does not use string
+    # view arguments to url()
+    from debug_panel.views import debug_data
+    from django.conf.urls import url
+
+    urlpatterns = [
+        url(r'^%s/data/(?P<cache_key>\d+\.\d+)/$' % _PREFIX, debug_data, name='debug_data'),
+    ]


### PR DESCRIPTION
This fixes urls.py so that the following errors do not come up when using Django 1.9:

```
debug_panel/urls.py:15: RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.
  url(r'^%s/data/(?P<cache_key>\d+\.\d+)/$' % _PREFIX, 'debug_data', name='debug_data'),

debug_panel/urls.py:15: RemovedInDjango110Warning: Support for string view arguments to url() is deprecated and will be removed in Django 1.10 (got debug_data). Pass the callable instead.
  url(r'^%s/data/(?P<cache_key>\d+\.\d+)/$' % _PREFIX, 'debug_data', name='debug_data'),

```