### PR TITLE
Fix double escaping on SQL panel.

### DIFF
--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -48,7 +48,6 @@ class DebugPanelMiddleware(debug_toolbar.middleware.DebugToolbarMiddleware):
 
         return res.func(request, *res.args, **res.kwargs)
 
-
     def process_response(self, request, response):
         """
         Store the DebugToolbarMiddleware rendered toolbar into a cache store.
@@ -63,7 +62,7 @@ class DebugPanelMiddleware(debug_toolbar.middleware.DebugToolbarMiddleware):
         if toolbar:
             # for django-debug-toolbar >= 1.4
             for panel in reversed(toolbar.enabled_panels):
-                if hasattr(panel, 'generate_stats'):
+                if hasattr(panel, 'generate_stats') and panel.panel_id != 'SQLPanel':
                     panel.generate_stats(request, response)
 
             cache_key = "%f" % time.time()


### PR DESCRIPTION
This should resolve https://github.com/django-debug-toolbar/django-debug-toolbar/issues/775.
There's probably a cleaner solution.  This just avoids calling
generate_stats() multiple times for the SQL panel since it looks like
the code escapes the raw SQL data in place.

Only tested this against django-debug-toolbar 1.4 with django
1.8.11 - may require tweaks to run against different versions.
