### PR TITLE
fix debug data 404

### DIFF
--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -42,7 +42,7 @@ class DebugPanelMiddleware(debug_toolbar.middleware.DebugToolbarMiddleware):
         """
 
         try:
-            res = resolve(request.path, urlconf=debug_panel.urls)
+            res = resolve(request.path_info, urlconf=debug_panel.urls)
         except Resolver404:
             return super(DebugPanelMiddleware, self).process_request(request)
 


### PR DESCRIPTION
[Use request.path_info instead of request.path](https://github.com/divio/django-cms/issues/3255)