### PR TITLE
Fixed deprecation warning in middleware.py for django 2.0

### DIFF
--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -4,6 +4,10 @@ Debug Panel middleware
 import threading
 import time
 
+try:
+    from django.urls import reverse, resolve, Resolver404
+except ImportError: # django < 2.0
+    from django.core.urlresolvers import reverse, resolve, Resolver404
 from django.core.urlresolvers import reverse, resolve, Resolver404
 from django.conf import settings
 from debug_panel.cache import cache

--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -8,7 +8,6 @@ try:
     from django.urls import reverse, resolve, Resolver404
 except ImportError: # django < 2.0
     from django.core.urlresolvers import reverse, resolve, Resolver404
-from django.core.urlresolvers import reverse, resolve, Resolver404
 from django.conf import settings
 from debug_panel.cache import cache
 import debug_toolbar.middleware


### PR DESCRIPTION
Update for django 2.0

`Importing from django.core.urlresolvers is deprecated in favor of django.urls.`
