### PR TITLE
Update to work with Django 2

### DIFF
--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -4,7 +4,7 @@ Debug Panel middleware
 import threading
 import time
 
-from django.core.urlresolvers import reverse, resolve, Resolver404
+from django.urls import reverse, resolve, Resolver404
 from django.conf import settings
 from debug_panel.cache import cache
 import debug_toolbar.middleware


### PR DESCRIPTION
@recamshak It looks like this tool broke in Django 2 when they moved around a couple imports; this is just a quick one-liner fix to make django-debug-panel know where to look now.