### PR TITLE
Update middleware.py

### DIFF
--- a/debug_panel/middleware.py
+++ b/debug_panel/middleware.py
@@ -4,7 +4,7 @@ Debug Panel middleware
 import threading
 import time
 
-from django.core.urlresolvers import reverse, resolve, Resolver404
+from django.urls import reverse, resolve, Resolver404
 from django.conf import settings
 from debug_panel.cache import cache
 import debug_toolbar.middleware


### PR DESCRIPTION
The django.core.urlresolvers module is removed in favor of its new location, django.urls.