### PR TITLE
fix: debug-panel not work by use rest_framework.schemas.get_schema_view

### DIFF
--- a/debug_panel/urls.py
+++ b/debug_panel/urls.py
@@ -14,5 +14,5 @@ except ImportError:  # django < 1.4
 _PREFIX = '__debug__'
 
 urlpatterns = [
-    url(r'^%s/data/(?P<cache_key>\d+\.\d+)/$' % _PREFIX, debug_data, name='debug_data'),
+    url(r'%s/data/(?P<cache_key>\d+\.\d+)/$' % _PREFIX, debug_data, name='debug_data'),
 ]


### PR DESCRIPTION
I use get_schema_view 
eg：
from rest_framework.schemas import get_schema_view
schema_view = get_schema_view(title='Foo', renderer_classes=[OpenAPIRenderer, SwaggerUIRenderer],
                              public=True, url='/foo/')
On Swagger UI , request url like /foo/xxx/xxx , docs url like  /foo/docs 
If use django debug panel, not work
Django log :
Not Found: /foo/__debug__/data/1578554723.038458/
Because rest_framework.schemas auto add prefix /foo ,
/foo/__debug__/data/ mismatch r'^%s/data/(?P<cache_key>\d+\.\d+)/$' 
I try  r'%s/data/(?P<cache_key>\d+\.\d+)/$' replace  r'^%s/data/(?P<cache_key>\d+\.\d+)/$' 
Bug fix.
Maybe all versions will be affected.

Version:
python2.7
ubuntu18.04
django(1.11.1)
django-rest-swagger (2.1.2)
djangorestframework (3.9.4)
django-debug-panel (0.8.3)
django-debug-toolbar (1.11)

Thank for u work , django-debug-panel  helped me a lot

